### PR TITLE
Fix convert

### DIFF
--- a/c_src/iconv_drv.c
+++ b/c_src/iconv_drv.c
@@ -243,7 +243,7 @@ static void iv_conv(t_iconvdrv *iv, iconv_t cd, char *ip, size_t ileft, char ign
 	    }
 	    buf = newbuf;
 	    op = buf + (olen - oleft - 1);
-	    olen += ileft + oleft;
+	    olen += ileft;
 	    oleft += ileft;
 	    /* keep going */
 	    continue;

--- a/src/iconv.erl
+++ b/src/iconv.erl
@@ -192,27 +192,3 @@ load_path(File) ->
 
 l2b(L) when is_list(L)   -> list_to_binary(L);
 l2b(B) when is_binary(B) -> B.
-
--ifdef(TEST).
-
-smtp_session_test_() ->
-	{setup,
-		fun() ->
-				iconv:start()
-		end,
-		fun(_) ->
-				iconv:stop()
-		end,
-		[
-			{"Convert from latin-1 to utf-8",
-				fun() ->
-						{ok, CD} = iconv:open("utf-8", "ISO-8859-1"),
-						?assertEqual({ok, <<"hello world">>}, iconv:conv(CD, "hello world")),
-						iconv:close(CD)
-				end
-			}
-		]
-	}.
-
-
-			-endif.

--- a/test/iconv_test.erl
+++ b/test/iconv_test.erl
@@ -1,0 +1,33 @@
+-module(iconv_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+mail_test_() ->
+    {setup, fun iconv:start/0,
+        fun(_) ->
+                iconv:stop()
+        end,
+        [
+            {"Convert from latin-1 to utf-8", fun latin2utf8/0}
+            , {"Convert from latin-1 to utf-8", fun utf82latin/0}
+            , {"Convert from windows-1251 to utf-8", fun windows2utf8/0}
+            ]
+    }.
+
+latin2utf8() ->
+    {ok, CD} = iconv:open("utf-8", "ISO-8859-1"),
+    ?assertEqual({ok, <<"hello world">>}, iconv:conv(CD, "hello world")),
+    iconv:close(CD).
+
+utf82latin() ->
+    {ok, CD} = iconv:open("ISO-8859-1", "utf-8"),
+    ?assertEqual({ok, <<"hello world">>}, iconv:conv(CD, "hello world")),
+    iconv:close(CD).
+
+windows2utf8() ->
+    {ok, CD} = iconv:open("utf-8", "windows-1251"),
+    ?assertEqual(
+        {ok, <<208,168,208,176,209,136,208,186,208,190,208,178,32,
+               208,148,208,181,208,189,208,184>>},
+        iconv:conv(CD, <<216,224,248,234,238,226,32,196,229,237,232>>)),
+    iconv:close(CD).


### PR DESCRIPTION
If we convert from one byte to many byte, then may happen next.

Example of convert from windows-1251 to utf-8:

iconv ask to realloc buffer. We alloc odd byte. Next call to iconv failed to
write 2 byte utf symbol and return last result. Convert ended without fully
converted string.

Also add test.

``` bash
iconv -f utf-8 -t windows-1251
Шашков Дени
Øàøêîâ Äåíè
```

New version:

``` erlang
4> iconv:start(), {ok, CD} = iconv:open("utf-8", "windows-1251"), V = <<"Øàøêîâ Äåíè">>, io:format("=~ts=~n", [element(2, iconv:conv(CD, V))]).
=Шашков Дени=
```

Old version:

``` erlang
1> iconv:start(), {ok, CD} = iconv:open("utf-8", "windows-1251"), V = <<"Øàøêîâ Äåíè">>, io:format("=~ts=~n", [element(2, iconv:conv(CD, V))]).
=Шашков Де=
```
