### PR TITLE
Fix a number of bugs, and add unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+*.beam
+*.app
+*.dump
+*.o
+*.so
+
+*.bak
+*~
+
+/.eunit

--- a/Rakefile
+++ b/Rakefile
@@ -169,8 +169,8 @@ task :compile => [:contrib, 'ebin', 'priv'] + HEADERS + OBJ + ['priv/iconv_drv.s
 end
 
 task :install => [:compile] do
-	sh "mkdir #{ROOTDIR}/lib/iconv-1.0.1" unless File.directory? "#{ROOTDIR}/lib/iconv-1.0.1"
-	sh "cp -r src ebin c_src priv #{ROOTDIR}/lib/iconv-1.0.1"
+	sh "mkdir #{ROOTDIR}/lib/iconv-1.0.2" unless File.directory? "#{ROOTDIR}/lib/iconv-1.0.2"
+	sh "cp -r src ebin c_src priv #{ROOTDIR}/lib/iconv-1.0.2"
 end
 
 task :contrib do

--- a/c_src/iconv_drv.c
+++ b/c_src/iconv_drv.c
@@ -86,7 +86,7 @@ typedef int ErlDrvSizeT;
 typedef int ErlDrvSSizeT;
 #endif
 
-static int driver_send_bin();
+static ErlDrvSSizeT driver_send_bin();
 
 /* atoms which are sent to erlang */
 static ErlDrvTermData am_ok;

--- a/c_src/iconv_drv.c
+++ b/c_src/iconv_drv.c
@@ -176,9 +176,10 @@ static ErlDrvSSizeT driver_send_error(t_iconvdrv *iv, ErlDrvTermData *am)
 #define get_int16(s) ((((unsigned char*)  (s))[0] << 8) | \
                       (((unsigned char*)  (s))[1]))
 
-
-#define put_int16(i, s) {((unsigned char*)(s))[0] = ((i) >> 8) & 0xff; \
-                        ((unsigned char*)(s))[1] = (i)         & 0xff;}
+#define get_int32(s) ((((unsigned char*)  (s))[0] << 24) | \
+                      (((unsigned char*)  (s))[1] << 16) | \
+                      (((unsigned char*)  (s))[2] <<  8) | \
+                      (((unsigned char*)  (s))[3]))
 
 static void iv_open(t_iconvdrv *iv, char *tocode, char *fromcode)
 {
@@ -321,15 +322,15 @@ static void iconvdrv_from_erlang(ErlDrvData drv_data, char *buf, ErlDrvSSizeT le
 
     case IV_CONV: {
 	/*
-	 * Format: <cd-len:16><cd><ignore><buf-len:16><buf>
+	 * Format: <cd-len:16><cd><ignore><buf-len:32><buf>
 	 */
 	i = get_int16(bp);
 	bp += 2;
 	memcpy(&cd, bp, i-1);
 	memcpy(&ignore, bp + i -1, 1);
 	bp += i;
-	i = get_int16(bp);
-	bp += 2;
+	i = get_int32(bp);
+	bp += 4;
 
 	iv_conv(iv, cd, bp, i, ignore);
 	break;

--- a/c_src/iconv_drv.c
+++ b/c_src/iconv_drv.c
@@ -76,6 +76,11 @@
   ((vec)[(i)+1] = (size)), \
   (i+2))
 
+/*
+ * R15B changed several driver callbacks to use ErlDrvSizeT and
+ * ErlDrvSSizeT typedefs instead of int.
+ * This provides missing typedefs on older OTP versions.
+ */
 #if ERL_DRV_EXTENDED_MAJOR_VERSION < 2
 typedef int ErlDrvSizeT;
 typedef int ErlDrvSSizeT;
@@ -344,7 +349,7 @@ static void iconvdrv_from_erlang(ErlDrvData drv_data, char *buf, ErlDrvSSizeT le
 
     } /* switch */
 
-    return ;
+    return;
 }
     
 
@@ -372,7 +377,8 @@ DRIVER_INIT(iconvdrv)
   iconvdrv_driver_entry.driver_name     = "iconv_drv";
   iconvdrv_driver_entry.finish          = NULL;
   iconvdrv_driver_entry.outputv         = NULL;
-  iconvdrv_driver_entry.ready_async     = NULL;
+/* Added in Erlang/OTP R15B: */
+  iconvdrv_driver_entry.ready_async     = NULL; 
   iconvdrv_driver_entry.flush           = NULL;
   iconvdrv_driver_entry.call            = NULL;
   iconvdrv_driver_entry.event           = NULL;

--- a/c_src/iconv_drv.c
+++ b/c_src/iconv_drv.c
@@ -244,8 +244,9 @@ static void iv_conv(t_iconvdrv *iv, iconv_t cd, char *ip, size_t ileft, char ign
 	    driver_send_error(iv, &am_einval);
 	} else if (errno == E2BIG) {
 	    char *newbuf;
+            int newolen = olen + ileft + oleft;
 	    /* allocate as much additional space as iconv says we need */
-	    newbuf = realloc(buf, olen + ileft + oleft);
+	    newbuf = realloc(buf, newolen);
 	    if (!newbuf) {
 		free(buf); /* realloc failed, make sure we free the old buffer*/
 		driver_send_error(iv, &am_enomem);
@@ -253,8 +254,8 @@ static void iv_conv(t_iconvdrv *iv, iconv_t cd, char *ip, size_t ileft, char ign
 	    }
 	    op = newbuf + (op - buf);
 	    buf = newbuf;
-	    olen += ileft + oleft;
-	    oleft += ileft;
+	    olen = newolen;
+	    oleft = olen - (op - buf);
 	    /* keep going */
 	    continue;
 	} else {

--- a/c_src/iconv_drv.c
+++ b/c_src/iconv_drv.c
@@ -229,7 +229,7 @@ static void iv_conv(t_iconvdrv *iv, iconv_t cd, char *ip, size_t ileft, char ign
 
     if (!buf) {
 	driver_send_error(iv, &am_enomem);
-	return;
+        return;
     }
 
     op = buf;
@@ -249,9 +249,8 @@ static void iv_conv(t_iconvdrv *iv, iconv_t cd, char *ip, size_t ileft, char ign
 	    /* allocate as much additional space as iconv says we need */
 	    newbuf = realloc(buf, newolen);
 	    if (!newbuf) {
-		free(buf); /* realloc failed, make sure we free the old buffer*/
 		driver_send_error(iv, &am_enomem);
-		return;
+		goto free_and_return;
 	    }
 	    op = newbuf + (op - buf);
 	    buf = newbuf;
@@ -262,7 +261,7 @@ static void iv_conv(t_iconvdrv *iv, iconv_t cd, char *ip, size_t ileft, char ign
 	} else {
 	    driver_send_error(iv, &am_unknown);
 	}
-	return;
+        goto free_and_return;
     }
 
     if (ileft == 0) {
@@ -277,6 +276,9 @@ static void iv_conv(t_iconvdrv *iv, iconv_t cd, char *ip, size_t ileft, char ign
 	}
     }
 
+free_and_return:
+    /* To ensure cleanup, this is the only exit point after an initial
+     * successful malloc. */
     free(buf);
 
     return;

--- a/c_src/iconv_drv.c
+++ b/c_src/iconv_drv.c
@@ -76,6 +76,11 @@
   ((vec)[(i)+1] = (size)), \
   (i+2))
 
+#if ERL_DRV_EXTENDED_MAJOR_VERSION < 2
+typedef int ErlDrvSizeT;
+typedef int ErlDrvSSizeT;
+#endif
+
 static int driver_send_bin();
 
 /* atoms which are sent to erlang */
@@ -115,7 +120,7 @@ static void iconvdrv_stop(ErlDrvData drv_data)
 
 
 /* send {P, value, Bin} to caller */
-static int driver_send_bin(t_iconvdrv *iv, ErlDrvBinary *bin, int len)
+static ErlDrvSSizeT driver_send_bin(t_iconvdrv *iv, ErlDrvBinary *bin, ErlDrvSizeT len)
 {
     int i = 0;
     ErlDrvTermData to, spec[10];
@@ -131,7 +136,7 @@ static int driver_send_bin(t_iconvdrv *iv, ErlDrvBinary *bin, int len)
 }
 
 /* send {P, ok} to caller */
-static int driver_send_ok(t_iconvdrv *iv)
+static ErlDrvSSizeT driver_send_ok(t_iconvdrv *iv)
 {
     int i = 0;
     ErlDrvTermData to, spec[10];
@@ -146,7 +151,7 @@ static int driver_send_ok(t_iconvdrv *iv)
 }
 
 /* send {P, error, Error} to caller */
-static int driver_send_error(t_iconvdrv *iv, ErlDrvTermData *am)
+static ErlDrvSSizeT driver_send_error(t_iconvdrv *iv, ErlDrvTermData *am)
 {
     int i = 0;
     ErlDrvTermData to, spec[8];
@@ -278,7 +283,7 @@ static void iv_close(t_iconvdrv *iv, iconv_t cd)
     return;
 }
 
-static void iconvdrv_from_erlang(ErlDrvData drv_data, char *buf, int len)
+static void iconvdrv_from_erlang(ErlDrvData drv_data, char *buf, ErlDrvSSizeT len)
 {
     t_iconvdrv *iv = (t_iconvdrv *) drv_data;
     char ignore = 0;
@@ -339,7 +344,7 @@ static void iconvdrv_from_erlang(ErlDrvData drv_data, char *buf, int len)
 
     } /* switch */
 
-    return;
+    return ;
 }
     
 
@@ -358,14 +363,25 @@ DRIVER_INIT(iconvdrv)
   am_e2big        = driver_mk_atom("e2big");
   am_unknown      = driver_mk_atom("unknown");
 
-  iconvdrv_driver_entry.init         = NULL;   /* Not used */
-  iconvdrv_driver_entry.start        = iconvdrv_start;
-  iconvdrv_driver_entry.stop         = iconvdrv_stop;
-  iconvdrv_driver_entry.output       = iconvdrv_from_erlang;
-  iconvdrv_driver_entry.ready_input  = NULL;
-  iconvdrv_driver_entry.ready_output = NULL;
-  iconvdrv_driver_entry.driver_name  = "iconv_drv";
-  iconvdrv_driver_entry.finish       = NULL;
-  iconvdrv_driver_entry.outputv      = NULL;
+  iconvdrv_driver_entry.init            = NULL;   /* Not used */
+  iconvdrv_driver_entry.start           = iconvdrv_start;
+  iconvdrv_driver_entry.stop            = iconvdrv_stop;
+  iconvdrv_driver_entry.output          = iconvdrv_from_erlang;
+  iconvdrv_driver_entry.ready_input     = NULL;
+  iconvdrv_driver_entry.ready_output    = NULL;
+  iconvdrv_driver_entry.driver_name     = "iconv_drv";
+  iconvdrv_driver_entry.finish          = NULL;
+  iconvdrv_driver_entry.outputv         = NULL;
+  iconvdrv_driver_entry.ready_async     = NULL;
+  iconvdrv_driver_entry.flush           = NULL;
+  iconvdrv_driver_entry.call            = NULL;
+  iconvdrv_driver_entry.event           = NULL;
+  iconvdrv_driver_entry.extended_marker = ERL_DRV_EXTENDED_MARKER;
+  iconvdrv_driver_entry.major_version   = ERL_DRV_EXTENDED_MAJOR_VERSION;
+  iconvdrv_driver_entry.minor_version   = ERL_DRV_EXTENDED_MINOR_VERSION;
+  iconvdrv_driver_entry.driver_flags    = 0;
+  iconvdrv_driver_entry.handle2         = NULL;
+  iconvdrv_driver_entry.process_exit    = NULL;
+  iconvdrv_driver_entry.stop_select     = NULL;
   return &iconvdrv_driver_entry;
 }

--- a/c_src/iconv_drv.c
+++ b/c_src/iconv_drv.c
@@ -251,8 +251,8 @@ static void iv_conv(t_iconvdrv *iv, iconv_t cd, char *ip, size_t ileft, char ign
 		driver_send_error(iv, &am_enomem);
 		return;
 	    }
+	    op = newbuf + (op - buf);
 	    buf = newbuf;
-	    op = buf + (olen - oleft - 1);
 	    olen += ileft + oleft;
 	    oleft += ileft;
 	    /* keep going */

--- a/c_src/iconv_drv.c
+++ b/c_src/iconv_drv.c
@@ -218,10 +218,10 @@ static void iv_conv(t_iconvdrv *iv, iconv_t cd, char *ip, size_t ileft, char ign
 {
     size_t oleft=ileft;
     char *op, *buf;
-    int olen = ileft + 1;
+    int olen = ileft;
     ErlDrvBinary *bin;
 
-    /* malloc enough for the input size +1 (null terminated),
+    /* malloc enough for the input size,
      * with the assumption that the output length will be close to the input
      * length. This isn't always the case, but we realloc on E2BIG below. */
     buf = malloc(olen);
@@ -263,11 +263,10 @@ static void iv_conv(t_iconvdrv *iv, iconv_t cd, char *ip, size_t ileft, char ign
 	}
 	return;
     }
-    *(op++) = 0; /* ensure we null terminate */
 
     if (ileft == 0) {
-	/* find the length of the result, minus the terminating NULL */
-	olen = strlen(buf);
+	/* find the length of the result */
+	olen = op - buf;
 	if (!(bin = driver_alloc_binary(olen))) {
 	    driver_send_error(iv, &am_enomem);
 	} else {

--- a/src/iconv.app.src
+++ b/src/iconv.app.src
@@ -1,6 +1,6 @@
 {application,iconv,
  [{description,"Interface to the iconv character set convertion library"},
-  {vsn,"1.0.1"},
+  {vsn,"1.0.2"},
   {modules,[]},
   {registered,[iconv]},
   {env, []},

--- a/src/iconv.erl
+++ b/src/iconv.erl
@@ -112,9 +112,13 @@ handle_call({open, To, From}, _, S) ->
 handle_call({conv, Cd, Buf}, _, S) ->
     CdLen  = byte_size(Cd),
     BufLen = byte_size(Buf),
-    Msg = <<?IV_CONV,CdLen:16,Cd/binary,BufLen:16,Buf/binary>>,
-    Reply = call_drv(S#state.port, Msg),
-    {reply, Reply, S};
+    if BufLen >= (1 bsl 16) ->
+            {reply, {error, {cannot_handle_large_input, BufLen}}, S};
+       true ->
+            Msg = <<?IV_CONV,CdLen:16,Cd/binary,BufLen:16,Buf/binary>>,
+            Reply = call_drv(S#state.port, Msg),
+            {reply, Reply, S}
+    end;
 
 %%
 handle_call({close, Cd}, _, S) ->

--- a/src/iconv.erl
+++ b/src/iconv.erl
@@ -112,10 +112,10 @@ handle_call({open, To, From}, _, S) ->
 handle_call({conv, Cd, Buf}, _, S) ->
     CdLen  = byte_size(Cd),
     BufLen = byte_size(Buf),
-    if BufLen >= (1 bsl 16) ->
+    if BufLen >= (1 bsl 32) ->
             {reply, {error, {cannot_handle_large_input, BufLen}}, S};
        true ->
-            Msg = <<?IV_CONV,CdLen:16,Cd/binary,BufLen:16,Buf/binary>>,
+            Msg = <<?IV_CONV,CdLen:16,Cd/binary,BufLen:32,Buf/binary>>,
             Reply = call_drv(S#state.port, Msg),
             {reply, Reply, S}
     end;

--- a/test/iconv_test.erl
+++ b/test/iconv_test.erl
@@ -1,0 +1,133 @@
+-module(iconv_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%%%========== Test collection ============================================
+iconv_test_() ->
+    {setup,
+     fun () -> {ok,_} = iconv:start() end,
+     fun(_) -> iconv:stop() end,
+     [
+      {"Convert from latin-1 to utf-8", fun latin1_to_utf8/0}
+      , {"Convert from utf-8 to latin-1 ", fun utf8_to_latin1/0}
+      , {"Big test", fun bigtest/0}
+      , {"Bad-input test", fun errortest/0}
+      , [{"Round-trip test "++CS++"->utf8->"++CS, fun() -> roundtrip(CS) end}
+         || CS <- ["latin1",
+                   "ISO-8859-1",
+                   "ISO-8859-2",
+                   "ISO-8859-3",
+                   "ISO-8859-4",
+                   "ISO-8859-5",
+                   "ISO-8859-6",
+                   "ISO-8859-7",
+                   "ISO-8859-8",
+                   "ISO-8859-9",
+                   "ISO-8859-10",
+                   "ISO-8859-11",
+                   "ISO-8859-13",
+                   "ISO-8859-14",
+                   "ISO-8859-15",
+                   "ISO-8859-16"]]
+     ]}.
+
+-ifdef(WITH_LEAK_TEST).
+leak_test_() ->
+     {setup,
+      fun () -> {ok,_} = iconv:start() end,
+      fun(_) -> iconv:stop() end,
+      {timeout, 120,
+       fun leaktest/0}}.
+-endif.
+
+%%%============================================================
+
+test_strings() ->
+    Latin1Characters = lists:seq(0,255),
+    [%% Basics:
+     "", "Hello, World!",
+     %% Non-ASCII characters:
+     "Blåbærgrød",
+     "test æøå",
+     "æøåÅØÆ",
+     [128,255]] ++
+        %% All one-character and two-character strings:
+        [[X] || X <- Latin1Characters] ++
+        [[X,Y] || X <- Latin1Characters, Y <- Latin1Characters] ++
+        %% Random input:
+        [crypto:rand_bytes(X) || X <- lists:seq(1,200)].
+
+latin1_to_utf8() ->
+    {ok, CD} = iconv:open("utf-8", "ISO-8859-1"),
+    [latin1_to_utf8(CD, X) || X <- test_strings()],
+    iconv:close(CD).
+
+latin1_to_utf8(CD, S) ->
+    In = list_to_binary(S),
+    Out = unicode:characters_to_binary(S, latin1),
+    ?assertEqual({ok, Out}, iconv:conv(CD, In)).
+
+
+utf8_to_latin1() ->
+    {ok, CD} = iconv:open("ISO-8859-1", "utf-8"),
+    [utf8_to_latin1(CD, X) || X <- test_strings()],
+    iconv:close(CD).
+
+utf8_to_latin1(CD, S) ->
+    In = unicode:characters_to_binary(S, latin1),
+    Out = list_to_binary(S),
+    ?assertEqual({ok, Out}, iconv:conv(CD, In)).
+
+roundtrip(CS) ->
+    Bytes = lists:seq(0,255),
+    TestStrings =
+        %% All zero-, one-, and two-byte sequences:
+        [<<>>] ++
+        [<<X>> || X <- Bytes] ++
+        [<<X,Y>> || X <- Bytes, Y <- Bytes] ++
+        %% Random input:
+        [crypto:rand_bytes(X) || X <- lists:seq(1,200)],
+
+    io:format(user, "using ~p test strings\n", [length(TestStrings)]),
+    {ok, CD1} = iconv:open("utf-8", CS),
+    {ok, CD2} = iconv:open(CS, "utf-8"),
+    [roundtrip(CD1, CD2, X) || X <- TestStrings],
+    iconv:close(CD1),
+    iconv:close(CD2).
+
+roundtrip(CD1, CD2, In) ->
+    {ok, Tmp} = iconv:conv(CD1, In),
+    ?assertEqual({ok, In}, iconv:conv(CD2, Tmp)).
+
+bigtest() ->
+    {ok, CD} = iconv:open("latin1", "utf-8"),
+    [begin
+         In = list_to_binary(string:copies("x",100*N)),
+         {ok,Out} = iconv:conv(CD, In),
+         %% io:format(user, "DB| ~w~n vs ~w~n", [In, iconv:conv(CD, In)]),
+         ?assertMatch({N,X,X}, {N,byte_size(In), byte_size(Out)}),
+         ?assertMatch({N,{ok,In}}, {N,iconv:conv(CD, In)})
+     end
+     || N <- lists:seq(655,1000)],
+    iconv:close(CD).
+
+errortest() ->
+    {ok, CD} = iconv:open("ISO-8859-1", "utf-8"),
+    ?assertEqual({ok, <<>>}, iconv:conv(CD, <<>>)),
+    ?assertEqual({error, eilseq}, iconv:conv(CD, <<2#10000000>>)),
+    ?assertEqual({error, einval}, iconv:conv(CD, <<2#11100000>>)),
+    ?assertEqual({error, einval}, iconv:conv(CD, <<2#11100000, 2#10000000>>)),
+    iconv:close(CD).
+
+leaktest() ->
+    In = list_to_binary(string:copies("x",60000)),
+    {ok, CD} = iconv:open("latin1", "utf-8"),
+    erlang:display(erlang:memory()),
+    [begin
+         ?assertMatch({error,eilseq}, iconv:conv(CD, <<In/binary, 16#80>>)),
+         ?assertMatch({error,einval}, iconv:conv(CD, <<In/binary, 16#E0>>))
+         %% timer:sleep(1)
+     end
+     || _ <- lists:seq(1,600000)],
+    erlang:display(erlang:memory()),
+    iconv:close(CD).

--- a/test/iconv_test.erl
+++ b/test/iconv_test.erl
@@ -56,7 +56,7 @@ test_strings() ->
         [[X] || X <- Latin1Characters] ++
         [[X,Y] || X <- Latin1Characters, Y <- Latin1Characters] ++
         %% Random input:
-        [crypto:rand_bytes(X) || X <- lists:seq(1,200)].
+        [binary_to_list(crypto:rand_bytes(X)) || X <- lists:seq(1,200)].
 
 double_expand() ->
     {ok, CD} = iconv:open("utf-8", "ISO-8859-1"),

--- a/test/iconv_test.erl
+++ b/test/iconv_test.erl
@@ -9,6 +9,7 @@ iconv_test_() ->
      fun(_) -> iconv:stop() end,
      [
       {"Convert from latin-1 to utf-8", fun latin1_to_utf8/0}
+      , {"Double-expand corruption", fun double_expand/0}
       , {"Convert from utf-8 to latin-1 ", fun utf8_to_latin1/0}
       , {"Big test", fun bigtest/0}
       , {"Bad-input test", fun errortest/0}
@@ -56,6 +57,11 @@ test_strings() ->
         [[X,Y] || X <- Latin1Characters, Y <- Latin1Characters] ++
         %% Random input:
         [crypto:rand_bytes(X) || X <- lists:seq(1,200)].
+
+double_expand() ->
+    {ok, CD} = iconv:open("utf-8", "ISO-8859-1"),
+    latin1_to_utf8(CD, "Test æøå"),
+    iconv:close(CD).
 
 latin1_to_utf8() ->
     {ok, CD} = iconv:open("utf-8", "ISO-8859-1"),

--- a/test/iconv_test.erl
+++ b/test/iconv_test.erl
@@ -96,7 +96,6 @@ roundtrip(CS) ->
         [bytes_not_in(crypto:rand_bytes(X), IllegalBytes)
          || X <- lists:seq(1,200)],
 
-    io:format(user, "using ~p test strings\n", [length(TestStrings)]),
     {ok, CD1} = iconv:open("utf-8", CS),
     {ok, CD2} = iconv:open(CS, "utf-8"),
     [roundtrip(CD1, CD2, X) || X <- TestStrings],


### PR DESCRIPTION
Bugs fixed:
- incorrect result when buffer was expanded more than once;
- memory leak on einval and eilseq returns;
- if input was >64KB, only first (n % 64K) bytes were processed, the rest being silently ignored;
- NULs handled in a way which makes little sense with Erlang.
